### PR TITLE
Remove API context var, remove deprecated code

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -41,7 +41,6 @@ const char *ca_chain_file;
 char *cert_file;
 char *key_file;
 const char *path_segment;
-const char *api_context;
 char value[JSON_STRING_LENGTH] = "same";
 
 #define CHECK_ENABLE_CAP_RV(rv) \
@@ -68,9 +67,6 @@ static void setup_session_parameters(void) {
 
     path_segment = getenv("AMV_URI_PREFIX");
     if (!path_segment) path_segment = DEFAULT_URI_PREFIX;
-
-    api_context = getenv("AMV_API_CONTEXT");
-    if (!api_context) api_context = "";
 
     ca_chain_file = getenv("AMV_CA_FILE");
     cert_file = getenv("AMV_CERT_FILE");
@@ -147,13 +143,6 @@ int main(int argc, char **argv) {
     rv = amvp_set_server(ctx, server, port);
     if (rv != AMVP_SUCCESS) {
         printf("Failed to set server/port\n");
-        goto end;
-    }
-
-    /* Set the api context prefix if needed */
-    rv = amvp_set_api_context(ctx, api_context);
-    if (rv != AMVP_SUCCESS) {
-        printf("Failed to set URI prefix\n");
         goto end;
     }
 

--- a/include/amvp/amvp.h
+++ b/include/amvp/amvp.h
@@ -2828,20 +2828,6 @@ AMVP_RESULT amvp_set_server(AMVP_CTX *ctx, const char *server_name, int port);
 AMVP_RESULT amvp_set_path_segment(AMVP_CTX *ctx, const char *path_segment);
 
 /**
- * @brief amvp_set_api_context() specifies the URI prefix used by the AMVP server. Some AMVP
- *        servers use a context string in the URI for the path to the REST interface. Calling this
- *        function allows the API context prefix to be specified. The value provided to this
- *        function is prepended to the path segment of the URI used for the AMVP REST calls.
- *
- * @param ctx Pointer to AMVP_CTX that was previously created by calling amvp_create_test_session.
- * @param api_context Value to embed in the URI path after the server name and before the AMVP
- *        well-known path.
- *
- * @return AMVP_RESULT
- */
-AMVP_RESULT amvp_set_api_context(AMVP_CTX *ctx, const char *api_context);
-
-/**
  * @brief amvp_set_cacerts() specifies PEM encoded certificates to use as the root trust anchors
  *        for establishing the TLS session with the AMVP server. AMVP uses TLS as the transport. In
  *        order to verify the identity of the AMVP server, the TLS stack requires one or more root

--- a/include/amvp/amvp_lcl.h
+++ b/include/amvp/amvp_lcl.h
@@ -16,6 +16,7 @@
 #define AMVP_LIBRARY_VERSION_NUMBER "0.1.0"
 #define AMVP_LIBRARY_VERSION    "libamvp_oss-0.1.0"
 
+#define AMVP_DEFAULT_PATH_SEGMENT "/amvp/v1"
 
 #ifndef AMVP_LOG_ERR
 #define AMVP_LOG_ERR(msg, ...) do { \
@@ -1710,7 +1711,6 @@ struct amvp_ctx_t {
     int debug;              /* Indicates if the ctx is set to run in "debug" mode for extra output */
     char *server_name;
     char *path_segment;
-    char *api_context;
     int server_port;
     char *cacerts_file;     /* Location of CA certificates Curl will use to verify peer */
     int verify_peer;        /* enables TLS peer verification via Curl */

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -82,7 +82,6 @@ EXPORTS
   amvp_free_test_session
   amvp_set_server
   amvp_set_path_segment
-  amvp_set_api_context
   amvp_set_cacerts
   amvp_set_certkey
   amvp_mark_as_sample

--- a/test/test_amvp.c
+++ b/test/test_amvp.c
@@ -16,7 +16,6 @@ AMVP_CTX *ctx;
 static char filename[] = "filename";
 static char cvalue[] = "same";
 char *test_server = "demo.amvts.nist.gov";
-char *api_context = "amvp/";
 char *path_segment = "amvp/v1/";
 char *uri = "login";
 int port = 443;
@@ -457,10 +456,7 @@ Test(FREE_TEST_SESSION, good_full, .init = setup_full_ctx) {
 Test(RUN, missing_path, .init = setup_full_ctx, .fini = teardown) {
     rv = amvp_set_server(ctx, test_server, port);
     cr_assert(rv == AMVP_SUCCESS);
-    
-    rv = amvp_set_api_context(ctx, api_context);
-    cr_assert(rv == AMVP_SUCCESS);
-    
+
     rv = amvp_set_server(ctx, test_server, port);
     cr_assert(rv == AMVP_SUCCESS);
     
@@ -480,9 +476,6 @@ Test(RUN, missing_path, .init = setup_full_ctx, .fini = teardown) {
  */
 Test(RUN, marked_as_get, .init = setup_full_ctx, .fini = teardown) {
     rv = amvp_set_server(ctx, test_server, port);
-    cr_assert(rv == AMVP_SUCCESS);
-    
-    rv = amvp_set_api_context(ctx, api_context);
     cr_assert(rv == AMVP_SUCCESS);
 
     rv = amvp_set_path_segment(ctx, path_segment);
@@ -511,9 +504,6 @@ Test(RUN, marked_as_get, .init = setup_full_ctx, .fini = teardown) {
  */
 Test(RUN, good, .init = setup_full_ctx, .fini = teardown) {
     rv = amvp_set_server(ctx, test_server, port);
-    cr_assert(rv == AMVP_SUCCESS);
-    
-    rv = amvp_set_api_context(ctx, api_context);
     cr_assert(rv == AMVP_SUCCESS);
     
     rv = amvp_set_path_segment(ctx, path_segment);
@@ -640,8 +630,6 @@ Test(REFRESH, null_ctx, .fini = teardown) {
  */
 Test(REFRESH, good_with_totp, .init = setup_full_ctx, .fini = teardown) {
     rv = amvp_set_server(ctx, test_server, port);
-    cr_assert(rv == AMVP_SUCCESS);
-    rv = amvp_set_api_context(ctx, api_context);
     cr_assert(rv == AMVP_SUCCESS);
     rv = amvp_set_path_segment(ctx, path_segment);
     cr_assert(rv == AMVP_SUCCESS);

--- a/test/test_amvp_operating_env.c
+++ b/test/test_amvp_operating_env.c
@@ -18,7 +18,6 @@ char *ca_chain_file;
 char *cert_file;
 char *key_file;
 char *path_segment;
-char *api_context;
 static AMVP_CTX *ctx = NULL;
 AMVP_RESULT rv;
 

--- a/test/test_amvp_transport.c
+++ b/test/test_amvp_transport.c
@@ -57,7 +57,6 @@ char *ca_chain_file;
 char *cert_file;
 char *key_file;
 char *path_segment;
-char *api_context;
 
 /*
  * Read the operational parameters from the various environment
@@ -70,7 +69,6 @@ static void test_setup_session_parameters(void)
     server = "noserver";
     port = 443;
     path_segment = "/amvp/v1/";
-    api_context = "amvp/";
     ca_chain_file = NULL;
     cert_file = NULL;
     key_file = NULL;
@@ -79,7 +77,6 @@ static void test_setup_session_parameters(void)
     amvp_set_cacerts(ctx, ca_chain_file);
     amvp_set_certkey(ctx, cert_file, key_file);
     amvp_set_path_segment(ctx, path_segment);
-    rv = amvp_set_api_context(ctx, api_context);
     amvp_set_2fa_callback(ctx, &dummy_totp);
 }
 


### PR DESCRIPTION
We can probably remove API context from libacvp too, will make a note to look at that.