### PR TITLE
Move amvVersion info, change URL parsing for certRequest session

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -61,7 +61,7 @@ static void setup_session_parameters(void) {
     key_file = getenv("AMV_KEY_FILE");
 
     printf("Using the following parameters:\n\n");
-    printf("    AMV_SERVER:     [Redacted for demo]\n");
+    printf("    AMV_SERVER:     %s\n", server);
     printf("    AMV_PORT:       %d\n", port);
     printf("    AMV_URI_PREFIX: %s\n", path_segment);
     if (ca_chain_file) printf("    AMV_CA_FILE:    [Redacted for demo]\n");

--- a/include/amvp/amvp_lcl.h
+++ b/include/amvp/amvp_lcl.h
@@ -1929,7 +1929,12 @@ const char *amvp_lookup_rsa_randpq_name(int value);
 
 int amvp_lookup_rsa_randpq_index(const char *value);
 
+#ifdef AMVP_OLD_JSON_FORMAT
 AMVP_RESULT amvp_create_array(JSON_Object **obj, JSON_Value **val, JSON_Array **arry);
+#else
+AMVP_RESULT amvp_create_response_obj(JSON_Object **obj, JSON_Value **val);
+AMVP_RESULT amvp_add_version_to_obj(JSON_Object *obj);
+#endif
 
 AMVP_RESULT is_valid_tf_param(int value);
 

--- a/metadata/module.json
+++ b/metadata/module.json
@@ -1,4 +1,5 @@
-[ { "amvVersion": "1.0" }, {
+{
+    "amvVersion": "1.0",
     "schemaVersion": "initial",
     "moduleInfo": {
         "name": "Cisco Example AMVP Cryptographic Module",
@@ -97,4 +98,3 @@
     "supportsBypassCapability": false,
     "hasOTPMemory": false
 }
-]

--- a/src/amvp_util.c
+++ b/src/amvp_util.c
@@ -826,6 +826,7 @@ AMVP_DRBG_CAP_GROUP *amvp_create_drbg_group(AMVP_DRBG_MODE_LIST *mode, int group
     return grp;
 }
 
+#ifdef AMVP_OLD_JSON_FORMAT
 /*
  * Creates a JSON amvp array which consists of
  * [{preamble}, {object}]
@@ -866,6 +867,28 @@ AMVP_RESULT amvp_create_array(JSON_Object **obj, JSON_Value **val, JSON_Array **
     *arry = reg_arry;
     return AMVP_SUCCESS;
 }
+#else
+AMVP_RESULT amvp_create_response_obj(JSON_Object **obj, JSON_Value **val) {
+    JSON_Value *tval = NULL;
+    JSON_Object *tobj = NULL;
+
+    tval = json_value_init_object();
+    tobj = json_value_get_object(tval);
+    if (!tobj) {
+        return AMVP_JSON_ERR;
+    }
+
+    json_object_set_string(tobj, "amvVersion", AMVP_VERSION);
+    *obj = tobj;
+    *val = tval;
+    return AMVP_SUCCESS;
+}
+
+AMVP_RESULT amvp_add_version_to_obj(JSON_Object *obj) {
+    json_object_set_string(obj, "amvVersion", AMVP_VERSION);
+    return AMVP_SUCCESS;
+}
+#endif
 
 /*
  * This function returns a string that describes the error
@@ -1035,9 +1058,12 @@ JSON_Object *amvp_get_obj_from_rsp(AMVP_CTX *ctx, JSON_Value *arry_val) {
         AMVP_LOG_ERR("Missing arguments");
         return NULL;
     }
+#ifdef AMVP_OLD_JSON_FORMAT
     reg_array = json_value_get_array(arry_val);
-
     obj = json_array_get_object(reg_array, 1);
+#else
+    obj = json_value_get_object(arry_val);
+#endif
     return obj;
 }
 


### PR DESCRIPTION
Gets rid of top-level array expectation; leaves old code in but ifdef-ed out for now. Also handle getting URL for certRequest instead of ID number. 