### PR TITLE
Add schema APIs and CLI options, adjust some validation on values

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -59,6 +59,15 @@ static void print_usage(int code) {
     printf("To GET status of request, such as validation or metadata:\n");
     printf("      --get <request string URL including ID>\n");
     printf("\n");
+    printf("To retrieve schema information from the server:\n");
+    printf("      --get_evidence_schema [version]\n");
+    printf("      --get_source_code_schema [version]\n");
+    printf("      --get_security_policy_schema [version]\n");
+    printf("      --get_other_documentation_schema [version]\n");
+    printf("      Omit version to list available versions. Provide version argument to fetch that schema.\n");
+    printf("      Only one schema type may be requested per invocation; if multiple are given, the first one is used.\n");
+    printf("      Use --save_to to save the result to a file instead of printing it.\n");
+    printf("\n");
     printf("To request to DELETE a resource you have created on the server:\n");
     printf("      --delete <url>\n");
     printf("\n");
@@ -133,6 +142,10 @@ static ko_longopt_t longopts[] = {
     { "get", ko_required_argument, 431 },
     { "delete", ko_required_argument, 432 },
     { "get_security_policy", ko_no_argument, 433 },
+    { "get_evidence_schema", ko_optional_argument, 441 },
+    { "get_source_code_schema", ko_optional_argument, 442 },
+    { "get_security_policy_schema", ko_optional_argument, 443 },
+    { "get_other_documentation_schema", ko_optional_argument, 444 },
     { "save_to", ko_required_argument, 451 },
     { "config", ko_required_argument, 452 },
     { "for_cert_request", ko_required_argument, 453 },
@@ -349,6 +362,66 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
 
         case 433:
             cfg->get_sp = 1;
+            break;
+
+        case 441:
+            if (cfg->get_schema) {
+                printf(ANSI_COLOR_YELLOW "Warning: multiple schema type options provided, ignoring.\n" ANSI_COLOR_RESET);
+                break;
+            }
+            cfg->get_schema = 1;
+            cfg->schema_type = AMVP_SCHEMA_EVIDENCE;
+            if (opt.arg) {
+                if (!check_option_length(opt.arg, c, APP_SCHEMA_VERSION_MAX_LEN)) {
+                    return 1;
+                }
+                strcpy_s(cfg->schema_version, APP_SCHEMA_VERSION_MAX_LEN + 1, opt.arg);
+            }
+            break;
+
+        case 442:
+            if (cfg->get_schema) {
+                printf(ANSI_COLOR_YELLOW "Warning: multiple schema type options provided, ignoring.\n" ANSI_COLOR_RESET);
+                break;
+            }
+            cfg->get_schema = 1;
+            cfg->schema_type = AMVP_SCHEMA_SOURCE_CODE;
+            if (opt.arg) {
+                if (!check_option_length(opt.arg, c, APP_SCHEMA_VERSION_MAX_LEN)) {
+                    return 1;
+                }
+                strcpy_s(cfg->schema_version, APP_SCHEMA_VERSION_MAX_LEN + 1, opt.arg);
+            }
+            break;
+
+        case 443:
+            if (cfg->get_schema) {
+                printf(ANSI_COLOR_YELLOW "Warning: multiple schema type options provided, ignoring.\n" ANSI_COLOR_RESET);
+                break;
+            }
+            cfg->get_schema = 1;
+            cfg->schema_type = AMVP_SCHEMA_SECURITY_POLICY;
+            if (opt.arg) {
+                if (!check_option_length(opt.arg, c, APP_SCHEMA_VERSION_MAX_LEN)) {
+                    return 1;
+                }
+                strcpy_s(cfg->schema_version, APP_SCHEMA_VERSION_MAX_LEN + 1, opt.arg);
+            }
+            break;
+
+        case 444:
+            if (cfg->get_schema) {
+                printf(ANSI_COLOR_YELLOW "Warning: multiple schema type options provided, ignoring.\n" ANSI_COLOR_RESET);
+                break;
+            }
+            cfg->get_schema = 1;
+            cfg->schema_type = AMVP_SCHEMA_OTHER_DOCUMENTATION;
+            if (opt.arg) {
+                if (!check_option_length(opt.arg, c, APP_SCHEMA_VERSION_MAX_LEN)) {
+                    return 1;
+                }
+                strcpy_s(cfg->schema_version, APP_SCHEMA_VERSION_MAX_LEN + 1, opt.arg);
+            }
             break;
 
         case 's':

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -25,6 +25,8 @@ extern "C"
 
 #define AMVP_CONFIG_CERT_REQUEST_ENV "AMVP_CONFIG_CERT_REQUEST"
 
+#define APP_SCHEMA_VERSION_MAX_LEN 32
+
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_YELLOW "\x1b[33m"
 #define ANSI_COLOR_RESET "\x1b[0m"
@@ -62,6 +64,9 @@ typedef struct app_config {
     int finalize;
     int check_status;
     int vendor_id;
+    int get_schema;
+    AMVP_SCHEMA_TYPE schema_type;
+    char schema_version[APP_SCHEMA_VERSION_MAX_LEN + 1];
 } APP_CONFIG;
 
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -26,8 +26,8 @@ static int app_setup_two_factor_auth(AMVP_CTX *ctx);
 const char *server;
 int port;
 const char *ca_chain_file;
-char *cert_file;
-char *key_file;
+const char *cert_file;
+const char *key_file;
 
 #define CHECK_ENABLE_CAP_RV(rv) \
     if (rv != AMVP_SUCCESS) { \
@@ -40,7 +40,7 @@ char *key_file;
  * variables.
  */
 static void setup_session_parameters(void) {
-    char *tmp;
+    const char *tmp;
 
     server = getenv("AMV_SERVER");
     if (!server) {
@@ -181,6 +181,22 @@ int main(int argc, char **argv) {
         rv = amvp_get(ctx, cfg.get_string);
         if (rv != AMVP_SUCCESS) {
             printf("Failed to perform GET request.\n");
+        }
+        goto end;
+    }
+
+    if (cfg.get_schema) {
+        if (cfg.save_to) {
+            rv = amvp_set_get_save_file(ctx, cfg.save_file);
+            if (rv != AMVP_SUCCESS) {
+                printf("Failed to set save file for schema request\n");
+                goto end;
+            }
+        }
+        rv = amvp_get_schema_info(ctx, cfg.schema_type,
+                cfg.schema_version[0] ? cfg.schema_version : NULL);
+        if (rv != AMVP_SUCCESS) {
+            printf("Failed to get schema info.\n");
         }
         goto end;
     }

--- a/include/amvp/amvp.h
+++ b/include/amvp/amvp.h
@@ -55,6 +55,18 @@ typedef enum amvp_evidence_type {
 } AMVP_EVIDENCE_TYPE;
 
 /**
+ * @enum AMVP_SCHEMA_TYPE
+ * @brief Identifies which schema endpoint to query.
+ */
+typedef enum amvp_schema_type {
+    AMVP_SCHEMA_EVIDENCE = 0,
+    AMVP_SCHEMA_SOURCE_CODE,
+    AMVP_SCHEMA_SECURITY_POLICY,
+    AMVP_SCHEMA_OTHER_DOCUMENTATION,
+    AMVP_SCHEMA_MAX
+} AMVP_SCHEMA_TYPE;
+
+/**
  * @enum AMVP_LOG_LVL
  * @brief This enum defines the different log levels for
  *        the AMVP client library. Each level also contains
@@ -214,7 +226,7 @@ AMVP_RESULT amvp_set_cacerts(AMVP_CTX *ctx, const char *ca_file);
  *
  * @return AMVP_RESULT
  */
-AMVP_RESULT amvp_set_certkey(AMVP_CTX *ctx, char *cert_file, char *key_file);
+AMVP_RESULT amvp_set_certkey(AMVP_CTX *ctx, const char *cert_file, const char *key_file);
 
 /**
  * @brief amvp_mark_as_sample() marks the registration as a sample. This function sets a flag that
@@ -360,6 +372,20 @@ AMVP_RESULT amvp_submit_security_policy_template(AMVP_CTX *ctx, const char *file
 AMVP_RESULT amvp_get_security_policy(AMVP_CTX *ctx);
 AMVP_RESULT amvp_read_cert_req_info_file(AMVP_CTX *ctx, const char *filename);
 AMVP_RESULT amvp_finalize_cert_request(AMVP_CTX *ctx);
+
+/**
+ * @brief amvp_get_schema_info() retrieves schema information from the server.
+ *        If version is NULL or empty, it fetches the list of available schema versions and
+ *        prints them. If a version string is provided, it fetches that specific schema and
+ *        either prints it or saves it to a file if amvp_set_get_save_file() has been called.
+ *
+ * @param ctx Pointer to AMVP_CTX that was previously created by calling amvp_init_cert_request.
+ * @param schema_type The type of schema to query, as defined by AMVP_SCHEMA_TYPE.
+ * @param version Optional version string (e.g. "0.2"). Pass NULL to list available versions.
+ *
+ * @return AMVP_RESULT
+ */
+AMVP_RESULT amvp_get_schema_info(AMVP_CTX *ctx, AMVP_SCHEMA_TYPE schema_type, const char *version);
 
 
 /** @} */

--- a/include/amvp/amvp_lcl.h
+++ b/include/amvp/amvp_lcl.h
@@ -474,6 +474,7 @@ AMVP_RESULT amvp_send_evidence(AMVP_CTX *ctx, AMVP_EVIDENCE_TYPE type, const cha
 AMVP_RESULT amvp_request_security_policy_generation(AMVP_CTX *ctx, const char *url, char *data);
 AMVP_RESULT amvp_send_security_policy(AMVP_CTX *ctx, const char *url, char *sp, int sp_len);
 AMVP_RESULT amvp_get_security_policy_json(AMVP_CTX *ctx, const char *url, JSON_Value **result);
+AMVP_RESULT amvp_get_schema(AMVP_CTX *ctx, AMVP_SCHEMA_TYPE schema_type, const char *version);
 
 AMVP_RESULT amvp_network_action(AMVP_CTX *ctx, AMVP_NET_ACTION action, const char *endpoint_path, const char *data, int data_len);
 AMVP_RESULT amvp_transport_get(AMVP_CTX *ctx, const char *endpoint_path);
@@ -523,6 +524,7 @@ AMVP_RESULT amvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const 
 
 /* Display/output functions */
 AMVP_RESULT amvp_output_cert_request_status(AMVP_CTX *ctx, JSON_Object *status_json);
+AMVP_RESULT amvp_output_schema_list(AMVP_CTX *ctx, const char *response_buf);
 
 /* Utility functions */
 AMVP_CERT_REQ_STATUS amvp_parse_cert_req_status_str(JSON_Object *json);

--- a/src/amvp.c
+++ b/src/amvp.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <ctype.h>
 #ifdef _WIN32
 #include <io.h>
 #include <Windows.h>
@@ -28,6 +29,31 @@
  * Forward prototypes for local functions
  */
 static AMVP_RESULT amvp_login(AMVP_CTX *ctx, int refresh);
+
+/*
+ * Validates that a string is non-NULL, non-empty, within max_len characters,
+ * and free of whitespace and control characters (including CR/LF).
+ * Logs the specific character-level failure reason via ctx.
+ */
+static AMVP_RESULT validate_param_string(AMVP_CTX *ctx, const char *str, size_t max_len) {
+    const char *p;
+    size_t len = 0;
+    if (!str || str[0] == '\0') {
+        AMVP_LOG_ERR("String must not be empty");
+        return AMVP_INVALID_ARG;
+    }
+    for (p = str; *p != '\0'; p++, len++) {
+        if (isspace((unsigned char)*p) || iscntrl((unsigned char)*p)) {
+            AMVP_LOG_ERR("String contains whitespace or control characters");
+            return AMVP_INVALID_ARG;
+        }
+        if (max_len > 0 && len >= max_len) {
+            AMVP_LOG_ERR("String exceeds maximum length of %zu characters", max_len);
+            return AMVP_INVALID_ARG;
+        }
+    }
+    return AMVP_SUCCESS;
+}
 
 static AMVP_RESULT amvp_parse_login(AMVP_CTX *ctx);
 
@@ -146,8 +172,8 @@ AMVP_RESULT amvp_set_server(AMVP_CTX *ctx, const char *server_name, int port) {
     if (!server_name || port < 1) {
         return AMVP_INVALID_ARG;
     }
-    if (strnlen_s(server_name, AMVP_SESSION_PARAMS_STR_LEN_MAX + 1) > AMVP_SESSION_PARAMS_STR_LEN_MAX) {
-        AMVP_LOG_ERR("Server name string(s) too long");
+    if (validate_param_string(ctx, server_name, AMVP_SESSION_PARAMS_STR_LEN_MAX) != AMVP_SUCCESS) {
+        AMVP_LOG_ERR("Invalid server name");
         return AMVP_INVALID_ARG;
     }
     if (ctx->server_name) {
@@ -186,8 +212,8 @@ AMVP_RESULT amvp_set_cacerts(AMVP_CTX *ctx, const char *ca_file) {
         return AMVP_MISSING_ARG;
     }
 
-    if (strnlen_s(ca_file, AMVP_SESSION_PARAMS_STR_LEN_MAX + 1) > AMVP_SESSION_PARAMS_STR_LEN_MAX) {
-        AMVP_LOG_ERR("CA filename is suspiciously long...");
+    if (validate_param_string(ctx, ca_file, AMVP_SESSION_PARAMS_STR_LEN_MAX) != AMVP_SUCCESS) {
+        AMVP_LOG_ERR("Invalid CA file path");
         return AMVP_INVALID_ARG;
     }
 
@@ -209,7 +235,7 @@ AMVP_RESULT amvp_set_cacerts(AMVP_CTX *ctx, const char *ca_file) {
  * should only be used when the AMVP server supports TLS client
  * authentication.
  */
-AMVP_RESULT amvp_set_certkey(AMVP_CTX *ctx, char *cert_file, char *key_file) {
+AMVP_RESULT amvp_set_certkey(AMVP_CTX *ctx, const char *cert_file, const char *key_file) {
     if (!ctx) {
         return AMVP_NO_CTX;
     }
@@ -217,9 +243,12 @@ AMVP_RESULT amvp_set_certkey(AMVP_CTX *ctx, char *cert_file, char *key_file) {
     if (!cert_file || !key_file) {
         return AMVP_MISSING_ARG;
     }
-    if (strnlen_s(cert_file, AMVP_SESSION_PARAMS_STR_LEN_MAX + 1) > AMVP_SESSION_PARAMS_STR_LEN_MAX ||
-        strnlen_s(key_file, AMVP_SESSION_PARAMS_STR_LEN_MAX + 1) > AMVP_SESSION_PARAMS_STR_LEN_MAX) {
-        AMVP_LOG_ERR("CA filename is suspiciously long...");
+    if (validate_param_string(ctx, cert_file, AMVP_SESSION_PARAMS_STR_LEN_MAX) != AMVP_SUCCESS) {
+        AMVP_LOG_ERR("Invalid cert file path");
+        return AMVP_INVALID_ARG;
+    }
+    if (validate_param_string(ctx, key_file, AMVP_SESSION_PARAMS_STR_LEN_MAX) != AMVP_SUCCESS) {
+        AMVP_LOG_ERR("Invalid key file path");
         return AMVP_INVALID_ARG;
     }
     if (ctx->tls_cert) { free(ctx->tls_cert); }
@@ -1548,4 +1577,64 @@ const char *amvp_version(void) {
 
 const char *amvp_protocol_version(void) {
     return AMVP_VERSION;
+}
+
+AMVP_RESULT amvp_get_schema_info(AMVP_CTX *ctx, AMVP_SCHEMA_TYPE schema_type, const char *version) {
+    AMVP_RESULT rv = AMVP_SUCCESS;
+
+    if (!ctx) {
+        return AMVP_NO_CTX;
+    }
+
+    /* Authenticate if needed */
+    if (!ctx->jwt_token) {
+        rv = amvp_login(ctx, 0);
+        if (rv != AMVP_SUCCESS) {
+            AMVP_LOG_ERR("Failed to login for schema request");
+            return rv;
+        }
+    }
+
+    rv = amvp_get_schema(ctx, schema_type, version);
+    if (rv == AMVP_PROTOCOL_RSP_ERR) {
+        rv = amvp_handle_protocol_error(ctx, ctx->error);
+        if (rv == AMVP_RETRY_OPERATION) {
+            rv = amvp_get_schema(ctx, schema_type, version);
+        }
+    }
+    if (rv != AMVP_SUCCESS) {
+        AMVP_LOG_ERR("Schema GET request failed");
+        return rv;
+    }
+
+    if (!ctx->curl_buf || strlen(ctx->curl_buf) == 0) {
+        AMVP_LOG_WARN("No response data received");
+        return AMVP_SUCCESS;
+    }
+
+    if (ctx->save_filename) {
+        FILE *fp = fopen(ctx->save_filename, "w");
+        if (!fp) {
+            AMVP_LOG_ERR("Failed to open save file: %s", ctx->save_filename);
+            return AMVP_INTERNAL_ERR;
+        }
+        if (fwrite(ctx->curl_buf, 1, strlen(ctx->curl_buf), fp) != strlen(ctx->curl_buf)) {
+            AMVP_LOG_ERR("Failed to write schema response to file: %s", ctx->save_filename);
+            fclose(fp);
+            return AMVP_INTERNAL_ERR;
+        }
+        fclose(fp);
+        AMVP_LOG_STATUS("Schema response saved to: %s", ctx->save_filename);
+    } else {
+        if (version && strnlen_s(version, AMVP_ATTR_URL_MAX) > 0) {
+            AMVP_LOG_STATUS("Schema response:\n%s", ctx->curl_buf);
+        } else {
+            rv = amvp_output_schema_list(ctx, ctx->curl_buf);
+            if (rv != AMVP_SUCCESS) {
+                AMVP_LOG_ERR("Failed to display schema list");
+            }
+        }
+    }
+
+    return AMVP_SUCCESS;
 }

--- a/src/amvp_display.c
+++ b/src/amvp_display.c
@@ -684,3 +684,92 @@ end:
     if (module_name) free(module_name);
     return result;
 }
+
+/* Output a formatted table of available schema versions */
+AMVP_RESULT amvp_output_schema_list(AMVP_CTX *ctx, const char *response_buf) {
+    JSON_Value *val = NULL;
+    JSON_Object *obj = NULL;
+    JSON_Array *schema_array = NULL;
+    char *table_msg = NULL;
+    int table_pos = 0;
+    size_t i = 0, arr_size = 0;
+    AMVP_RESULT result = AMVP_SUCCESS;
+
+    if (!ctx || !response_buf || strlen(response_buf) == 0) {
+        return AMVP_MISSING_ARG;
+    }
+
+    val = json_parse_string(response_buf);
+    if (!val) {
+        AMVP_LOG_ERR("Failed to parse schema list JSON");
+        return AMVP_JSON_ERR;
+    }
+
+    obj = amvp_get_obj_from_rsp(ctx, val);
+    if (!obj) {
+        AMVP_LOG_ERR("Failed to get object from schema list response");
+        result = AMVP_JSON_ERR;
+        goto end;
+    }
+
+    schema_array = json_object_get_array(obj, "schemaList");
+    if (!schema_array) {
+        AMVP_LOG_ERR("Missing schemaList in schema list response");
+        result = AMVP_JSON_ERR;
+        goto end;
+    }
+
+    table_msg = calloc(AMVP_DISPLAY_TABLE_MSG_MAX, sizeof(char));
+    if (!table_msg) {
+        result = AMVP_MALLOC_FAIL;
+        goto end;
+    }
+
+    table_pos += snprintf(table_msg + table_pos, AMVP_DISPLAY_TABLE_MSG_MAX - table_pos,
+                         "\nAvailable Schema Versions\n");
+    table_pos += snprintf(table_msg + table_pos, AMVP_DISPLAY_TABLE_MSG_MAX - table_pos,
+                         "  %-12s  %-12s  %s\n", "Version", "Status", "Endpoint");
+    table_pos += snprintf(table_msg + table_pos, AMVP_DISPLAY_TABLE_MSG_MAX - table_pos,
+                         "  %-12s  %-12s  %s\n", "-------", "------", "--------");
+
+    arr_size = json_array_get_count(schema_array);
+    for (i = 0; i < arr_size; i++) {
+        JSON_Object *entry = json_array_get_object(schema_array, i);
+        const char *entry_version = NULL;
+        const char *entry_status = NULL;
+        const char *entry_endpoint = NULL;
+        const char *color = AMVP_ANSI_COLOR_RESET;
+        int diff = 0;
+
+        if (!entry) continue;
+
+        entry_version  = json_object_get_string(entry, "version");
+        entry_status   = json_object_get_string(entry, "status");
+        entry_endpoint = json_object_get_string(entry, "endpoint");
+
+        if (!entry_version)  entry_version  = "?";
+        if (!entry_status)   entry_status   = "?";
+        if (!entry_endpoint) entry_endpoint = "?";
+
+        strncmp_s(entry_status, 9, "preferred", 9, &diff);
+        if (!diff) {
+            color = AMVP_ANSI_COLOR_GREEN;
+        } else {
+            strncmp_s(entry_status, 10, "deprecated", 10, &diff);
+            if (!diff) {
+                color = AMVP_ANSI_COLOR_YELLOW;
+            }
+        }
+
+        table_pos += snprintf(table_msg + table_pos, AMVP_DISPLAY_TABLE_MSG_MAX - table_pos,
+                             "  %-12s  %s%-12s" AMVP_ANSI_COLOR_RESET "  %s\n",
+                             entry_version, color, entry_status, entry_endpoint);
+    }
+
+    AMVP_LOG_TABLE("%s", table_msg);
+
+end:
+    if (table_msg) free(table_msg);
+    if (val) json_value_free(val);
+    return result;
+}

--- a/src/amvp_endpoints.c
+++ b/src/amvp_endpoints.c
@@ -25,6 +25,7 @@
 #define AMVP_CERT_REQUESTS_PATH "certRequests"
 #define AMVP_MODULES_PATH "modules"
 #define AMVP_SP_TEMPLATE_PATH "securityPolicy/template"
+#define AMVP_SCHEMAS_PATH "schemas"
 
 /* Helper function declarations */
 static char* build_evidence_path(const char *base_path, const char *evidence_type);
@@ -439,5 +440,54 @@ AMVP_RESULT amvp_send_get_request(AMVP_CTX *ctx, const char *endpoint_path) {
     }
 
     rv = amvp_transport_get(ctx, endpoint_path);
+    return rv;
+}
+
+/*
+ * GET a schema endpoint. If version is NULL or empty, fetches the list of
+ * available versions for that schema type. Otherwise fetches the specific
+ * versioned schema.
+ */
+AMVP_RESULT amvp_get_schema(AMVP_CTX *ctx, AMVP_SCHEMA_TYPE schema_type, const char *version) {
+    const char *type_seg = NULL;
+    char *schema_path = NULL;
+    AMVP_RESULT rv;
+
+    if (!ctx) return AMVP_NO_CTX;
+
+    switch (schema_type) {
+    case AMVP_SCHEMA_EVIDENCE:
+        type_seg = AMVP_FT_EVIDENCE_PATH;
+        break;
+    case AMVP_SCHEMA_SOURCE_CODE:
+        type_seg = AMVP_SC_EVIDENCE_PATH;
+        break;
+    case AMVP_SCHEMA_SECURITY_POLICY:
+        type_seg = AMVP_SP_PATH;
+        break;
+    case AMVP_SCHEMA_OTHER_DOCUMENTATION:
+        type_seg = AMVP_OD_EVIDENCE_PATH;
+        break;
+    case AMVP_SCHEMA_MAX:
+    default:
+        AMVP_LOG_ERR("Invalid schema type");
+        return AMVP_INVALID_ARG;
+    }
+
+    schema_path = calloc(AMVP_ATTR_URL_MAX + 1, sizeof(char));
+    if (!schema_path) {
+        return AMVP_MALLOC_FAIL;
+    }
+
+    if (version && strnlen_s(version, AMVP_ATTR_URL_MAX) > 0) {
+        snprintf(schema_path, AMVP_ATTR_URL_MAX, "%s/%s/%s/%s",
+                 AMVP_DEFAULT_PATH_SEGMENT, AMVP_SCHEMAS_PATH, type_seg, version);
+    } else {
+        snprintf(schema_path, AMVP_ATTR_URL_MAX, "%s/%s/%s",
+                 AMVP_DEFAULT_PATH_SEGMENT, AMVP_SCHEMAS_PATH, type_seg);
+    }
+
+    rv = amvp_transport_get(ctx, schema_path);
+    free(schema_path);
     return rv;
 }


### PR DESCRIPTION
For accessing schemas, added new APIs and CLI arguments:
`--get_evidence_schema [version]`
`--get_source_code_schema [version]`
`--get_security_policy_schema [version]`
`--get_other_documentation_schema [version]`

Using any of these without the version argument will return the list of available schema versions for that endpoint and their statuses in a nice table.

When the version IS provided, it will either print the schema JSON in output logs, or can be used with the `--save_to` argument to save the JSON schema to a file. I chose not to implement a whole CLI JSON schema viewer. 

Additionally, added some more basic validation on user-provided config values, to handle CRLF line endings more sanely and such.